### PR TITLE
replace deprecated functions for arrow 19.0.0

### DIFF
--- a/src/DatatypeStore.cpp
+++ b/src/DatatypeStore.cpp
@@ -364,7 +364,7 @@ K decimal128(K precision, K scale)
   if (precision->i < 1 || precision->i > 38)
     return krr((S)"precision out of range, required: 1 <= precision <= 38");
 
-  return ki(kx::arrowkdb::GetDatatypeStore()->Add(arrow::decimal(precision->i, scale->i)));
+  return ki(kx::arrowkdb::GetDatatypeStore()->Add(arrow::smallest_decimal(precision->i, scale->i)));
 }
 
 K getPrecisionScale(K datatype_id)

--- a/src/TableData.cpp
+++ b/src/TableData.cpp
@@ -201,10 +201,7 @@ K writeParquet(K parquet_file, K schema_id, K array_data, K options)
   // Parquet version
   std::string parquet_version;
   write_options.GetStringOption(kx::arrowkdb::Options::PARQUET_VERSION, parquet_version);
-  if (parquet_version == "V2.0") {
-    parquet_props_builder.version(parquet::ParquetVersion::PARQUET_2_0);
-    parquet_props_builder.data_page_version(parquet::ParquetDataPageVersion::V2);
-  } else if (parquet_version == "V2.4") {
+  if (parquet_version == "V2.4") {
     parquet_props_builder.version(parquet::ParquetVersion::PARQUET_2_4);
     parquet_props_builder.data_page_version(parquet::ParquetDataPageVersion::V2);
   } else if (parquet_version == "V2.6") {
@@ -252,7 +249,7 @@ K readParquetSchema(K parquet_file)
       arrow::default_memory_pool()));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
   std::shared_ptr<arrow::Schema> schema;
   PARQUET_THROW_NOT_OK(reader->GetSchema(&schema));
@@ -286,7 +283,7 @@ K readParquetNumRowGroups(K parquet_file)
       arrow::default_memory_pool()));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
   return ki(reader->num_row_groups());
 
@@ -328,7 +325,7 @@ K readParquetData(K parquet_file, K options)
   }
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
   reader->set_use_threads(parquet_multithreaded_read);
 
@@ -385,7 +382,7 @@ K readParquetColumn(K parquet_file, K column_index, K options)
       arrow::default_memory_pool()));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
   std::shared_ptr<::arrow::ChunkedArray> chunked_array;
   PARQUET_THROW_NOT_OK(reader->ReadColumn(column_index->i, &chunked_array));
@@ -448,7 +445,7 @@ K readParquetRowGroups(K parquet_file, K row_groups, K columns, K options)
   }
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
-  PARQUET_THROW_NOT_OK(parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
   reader->set_use_threads(parquet_multithreaded_read);
 


### PR DESCRIPTION
works after arrow goes version beyond 19.0.0